### PR TITLE
dev(prisma): update schema and reset migrations to fix drift issue

### DIFF
--- a/backend/prisma/migrations/20250607131208_schema_updates_khiba/migration.sql
+++ b/backend/prisma/migrations/20250607131208_schema_updates_khiba/migration.sql
@@ -1,0 +1,192 @@
+/*
+  Warnings:
+
+  - You are about to drop the `beta_subscribers` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tour_images` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tour_prices` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tours` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `users` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."tour_images" DROP CONSTRAINT "tour_images_tourId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tour_prices" DROP CONSTRAINT "tour_prices_tourId_fkey";
+
+-- DropTable
+DROP TABLE "public"."beta_subscribers";
+
+-- DropTable
+DROP TABLE "public"."tour_images";
+
+-- DropTable
+DROP TABLE "public"."tour_prices";
+
+-- DropTable
+DROP TABLE "public"."tours";
+
+-- DropTable
+DROP TABLE "public"."users";
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'USER',
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "beta_subscribers" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+
+    CONSTRAINT "beta_subscribers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tours" (
+    "id" SERIAL NOT NULL,
+    "uniqueId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "location" TEXT,
+    "countryId" INTEGER NOT NULL,
+    "durationInDays" INTEGER NOT NULL DEFAULT 0,
+    "itinerary" TEXT,
+    "accommodationType" TEXT,
+    "siteURL" TEXT,
+    "included" TEXT,
+    "excluded" TEXT,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "archived" BOOLEAN NOT NULL DEFAULT false,
+    "operatorId" INTEGER,
+
+    CONSTRAINT "tours_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_images" (
+    "id" SERIAL NOT NULL,
+    "imageUrls" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "tourId" INTEGER NOT NULL,
+    "tourUniqueId" TEXT NOT NULL,
+
+    CONSTRAINT "tour_images_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_prices" (
+    "id" SERIAL NOT NULL,
+    "numOfPeople" INTEGER NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL,
+    "pricePerPerson" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "seasonName" TEXT,
+    "seasonPeriod" TEXT,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "tourId" INTEGER NOT NULL,
+    "tourUniqueId" TEXT NOT NULL,
+
+    CONSTRAINT "tour_prices_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "parks" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "parks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_parks" (
+    "tourId" INTEGER NOT NULL,
+    "parkId" INTEGER NOT NULL,
+
+    CONSTRAINT "tour_parks_pkey" PRIMARY KEY ("tourId","parkId")
+);
+
+-- CreateTable
+CREATE TABLE "countries" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "countries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "operators" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "operators_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_TourParks" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_TourParks_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "beta_subscribers_email_key" ON "beta_subscribers"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tours_uniqueId_key" ON "tours"("uniqueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tours_id_uniqueId_key" ON "tours"("id", "uniqueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "parks_name_key" ON "parks"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "countries_name_key" ON "countries"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "operators_name_key" ON "operators"("name");
+
+-- CreateIndex
+CREATE INDEX "_TourParks_B_index" ON "_TourParks"("B");
+
+-- AddForeignKey
+ALTER TABLE "tours" ADD CONSTRAINT "tours_countryId_fkey" FOREIGN KEY ("countryId") REFERENCES "countries"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tours" ADD CONSTRAINT "tours_operatorId_fkey" FOREIGN KEY ("operatorId") REFERENCES "operators"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_images" ADD CONSTRAINT "tour_images_tourId_tourUniqueId_fkey" FOREIGN KEY ("tourId", "tourUniqueId") REFERENCES "tours"("id", "uniqueId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_prices" ADD CONSTRAINT "tour_prices_tourId_tourUniqueId_fkey" FOREIGN KEY ("tourId", "tourUniqueId") REFERENCES "tours"("id", "uniqueId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_parks" ADD CONSTRAINT "tour_parks_tourId_fkey" FOREIGN KEY ("tourId") REFERENCES "tours"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_parks" ADD CONSTRAINT "tour_parks_parkId_fkey" FOREIGN KEY ("parkId") REFERENCES "parks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TourParks" ADD CONSTRAINT "_TourParks_A_fkey" FOREIGN KEY ("A") REFERENCES "parks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TourParks" ADD CONSTRAINT "_TourParks_B_fkey" FOREIGN KEY ("B") REFERENCES "tours"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20250607132755_remove_redunt_tour_park_relation/migration.sql
+++ b/backend/prisma/migrations/20250607132755_remove_redunt_tour_park_relation/migration.sql
@@ -1,0 +1,216 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_TourParks` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `beta_subscribers` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `countries` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `operators` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `parks` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tour_images` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tour_parks` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tour_prices` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `tours` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `users` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."_TourParks" DROP CONSTRAINT "_TourParks_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."_TourParks" DROP CONSTRAINT "_TourParks_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tour_images" DROP CONSTRAINT "tour_images_tourId_tourUniqueId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tour_parks" DROP CONSTRAINT "tour_parks_parkId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tour_parks" DROP CONSTRAINT "tour_parks_tourId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tour_prices" DROP CONSTRAINT "tour_prices_tourId_tourUniqueId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tours" DROP CONSTRAINT "tours_countryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."tours" DROP CONSTRAINT "tours_operatorId_fkey";
+
+-- DropTable
+DROP TABLE "public"."_TourParks";
+
+-- DropTable
+DROP TABLE "public"."beta_subscribers";
+
+-- DropTable
+DROP TABLE "public"."countries";
+
+-- DropTable
+DROP TABLE "public"."operators";
+
+-- DropTable
+DROP TABLE "public"."parks";
+
+-- DropTable
+DROP TABLE "public"."tour_images";
+
+-- DropTable
+DROP TABLE "public"."tour_parks";
+
+-- DropTable
+DROP TABLE "public"."tour_prices";
+
+-- DropTable
+DROP TABLE "public"."tours";
+
+-- DropTable
+DROP TABLE "public"."users";
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'USER',
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "beta_subscribers" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+
+    CONSTRAINT "beta_subscribers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tours" (
+    "id" SERIAL NOT NULL,
+    "uniqueId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "location" TEXT,
+    "countryId" INTEGER NOT NULL,
+    "durationInDays" INTEGER NOT NULL DEFAULT 0,
+    "itinerary" TEXT,
+    "accommodationType" TEXT,
+    "siteURL" TEXT,
+    "included" TEXT,
+    "excluded" TEXT,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "archived" BOOLEAN NOT NULL DEFAULT false,
+    "operatorId" INTEGER,
+
+    CONSTRAINT "tours_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_images" (
+    "id" SERIAL NOT NULL,
+    "imageUrls" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "tourId" INTEGER NOT NULL,
+    "tourUniqueId" TEXT NOT NULL,
+
+    CONSTRAINT "tour_images_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tour_prices" (
+    "id" SERIAL NOT NULL,
+    "numOfPeople" INTEGER NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL,
+    "pricePerPerson" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "seasonName" TEXT,
+    "seasonPeriod" TEXT,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+    "tourId" INTEGER NOT NULL,
+    "tourUniqueId" TEXT NOT NULL,
+
+    CONSTRAINT "tour_prices_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "parks" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "parks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "countries" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "countries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "operators" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "dateCreated" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "dateModified" TIMESTAMP(3),
+
+    CONSTRAINT "operators_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_TourParks" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+
+    CONSTRAINT "_TourParks_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "beta_subscribers_email_key" ON "beta_subscribers"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tours_uniqueId_key" ON "tours"("uniqueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tours_id_uniqueId_key" ON "tours"("id", "uniqueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "parks_name_key" ON "parks"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "countries_name_key" ON "countries"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "operators_name_key" ON "operators"("name");
+
+-- CreateIndex
+CREATE INDEX "_TourParks_B_index" ON "_TourParks"("B");
+
+-- AddForeignKey
+ALTER TABLE "tours" ADD CONSTRAINT "tours_countryId_fkey" FOREIGN KEY ("countryId") REFERENCES "countries"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tours" ADD CONSTRAINT "tours_operatorId_fkey" FOREIGN KEY ("operatorId") REFERENCES "operators"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_images" ADD CONSTRAINT "tour_images_tourId_tourUniqueId_fkey" FOREIGN KEY ("tourId", "tourUniqueId") REFERENCES "tours"("id", "uniqueId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tour_prices" ADD CONSTRAINT "tour_prices_tourId_tourUniqueId_fkey" FOREIGN KEY ("tourId", "tourUniqueId") REFERENCES "tours"("id", "uniqueId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TourParks" ADD CONSTRAINT "_TourParks_A_fkey" FOREIGN KEY ("A") REFERENCES "parks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TourParks" ADD CONSTRAINT "_TourParks_B_fkey" FOREIGN KEY ("B") REFERENCES "tours"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,36 +27,39 @@ model BetaSubscribers {
 
 model Tour {
   id                Int         @id @default(autoincrement())
-  uniqueId          Int         @unique
+  uniqueId          String      @unique
   title             String
   description       String?
-  location          String
-  country           String
+  location          String?
+  countryId         Int
+  country           Country     @relation(fields: [countryId], references: [id])
   durationInDays    Int         @default(0)
   itinerary         String?
-  safariType        String?
   accommodationType String?
   siteURL           String?
   included          String?
   excluded          String?
-  rating            Float?      @default(0)
-  reviews           String?
   dateCreated       DateTime    @default(now())
   dateModified      DateTime?   @updatedAt
   archived          Boolean     @default(false)
   images            TourImage[]
   prices            TourPrice[]
+  parksId           Park[]      @relation("TourParks")
+  operatorId        Int?
+  operator          Operator?   @relation(fields: [operatorId], references: [id], onDelete: SetNull)
 
+  @@unique([id, uniqueId])
   @@map("tours")
 }
 
 model TourImage {
   id           Int       @id @default(autoincrement())
-  image_urls   String
+  imageUrls    String
   dateCreated  DateTime  @default(now())
   dateModified DateTime? @updatedAt
   tourId       Int
-  tour         Tour      @relation(fields: [tourId], references: [uniqueId], onDelete: Cascade)
+  tourUniqueId String
+  tour         Tour      @relation(fields: [tourId, tourUniqueId], references: [id, uniqueId], onDelete: Cascade)
 
   @@map("tour_images")
 }
@@ -66,12 +69,43 @@ model TourPrice {
   numOfPeople    Int       @default(0)
   currency       String
   pricePerPerson Float     @default(0)
-  seasonName     String
-  seasonPeriod   String
+  seasonName     String?
+  seasonPeriod   String?
   dateCreated    DateTime  @default(now())
   dateModified   DateTime? @updatedAt
-  tourId         Int       @default(0)
-  tour           Tour      @relation(fields: [tourId], references: [uniqueId], onDelete: Cascade)
+  tourId         Int
+  tourUniqueId   String
+  tour           Tour      @relation(fields: [tourId, tourUniqueId], references: [id, uniqueId], onDelete: Cascade)
 
   @@map("tour_prices")
+}
+
+model Park {
+  id           Int       @id @default(autoincrement())
+  name         String    @unique
+  dateCreated  DateTime  @default(now())
+  dateModified DateTime? @updatedAt
+  toursId      Tour[]    @relation("TourParks")
+
+  @@map("parks")
+}
+
+model Country {
+  id           Int       @id @default(autoincrement())
+  name         String    @unique
+  dateCreated  DateTime  @default(now())
+  dateModified DateTime? @updatedAt
+  tours        Tour[]
+
+  @@map("countries")
+}
+
+model Operator {
+  id           Int       @id @default(autoincrement())
+  name         String    @unique
+  dateCreated  DateTime  @default(now())
+  dateModified DateTime? @updatedAt
+  tours        Tour[]
+
+  @@map("operators")
 }


### PR DESCRIPTION
**Prisma schema update**

Updated the prisma schema:

Changing to the latest structure of the **tours** table.
Added the **parks**, **countries** and **operators** models as well as their relation to the **tours** table.

*Note - I have created a join table _TourParks for a many to many relationship, that will allow querying multiple tours from a single park and/or multiple parks from a single park.