### PR TITLE
Refactor/user supabase logic to service layer

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -4,6 +4,8 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 
 import { logger } from '../utils/logger';
 
+import type { AuthenticatedUser } from '../types/types';
+
 const supabaseJwtSecret = process.env.SUPABASE_JWT_SECRET as string;
 
 if (!supabaseJwtSecret) throw new Error('SUPABASE_JWT_SECRET is not set. Check your .env file.');
@@ -29,8 +31,8 @@ export async function authenticateToken(req: Request, res: Response, next: NextF
   }
 
   try {
-    const decoded = (await verifyJwt(token, supabaseJwtSecret)) as JwtPayload;
-    req.user = decoded as JwtPayload;
+    const decoded = (await verifyJwt(token, supabaseJwtSecret)) as AuthenticatedUser;
+    req.user = decoded;
     logger.info('User authenticated:', { sub: decoded.sub, role: decoded.role });
     next();
   } catch (err) {

--- a/backend/src/middleware/authorizeRoles.ts
+++ b/backend/src/middleware/authorizeRoles.ts
@@ -1,18 +1,17 @@
 import { Request, Response, NextFunction } from 'express';
-import { User } from '../types/types';
 
 // Role-Based Access Control (RBAC) guard for Express routes. It ensures that only users with specific roles (like "ADMIN" or "USER") can access a given route.
 
 export const authorizeRoles = (...roles: string[]) => {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const user = req.user as User;
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const user = req.user;
 
     if (!user) {
       res.status(403).json({ error: 'Access denied: no role provided' });
       return;
     }
 
-    if (!roles.includes(user.role)) {
+    if (!user.role || !roles.includes(user.role)) {
       res.status(403).json({
         error: 'Access denied: insufficient permissions',
       });

--- a/backend/src/providers/supabase.provider.ts
+++ b/backend/src/providers/supabase.provider.ts
@@ -1,5 +1,5 @@
-import { createClient, Session, User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '../config/supabase';
+import { createClient, Session, User as SupabaseUser } from '@supabase/supabase-js';
 
 import { formatSupabaseError } from '../utils/supabaseErrorHandler';
 

--- a/backend/src/providers/supabase.provider.ts
+++ b/backend/src/providers/supabase.provider.ts
@@ -3,7 +3,7 @@ import { supabase } from '../config/supabase';
 
 import { formatSupabaseError } from '../utils/supabaseErrorHandler';
 
-type SupabaseResult<T> = { success: true; data: T } | { success: false; error: string };
+import { ServiceResponse as SupabaseResult } from '../types/types';
 
 export const SupabaseProvider = {
   client: supabase, // Expose Supabase client instance

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -1,11 +1,13 @@
 import { Request, Response, Router } from 'express';
 
+import { AdminService } from '../services/admin.service';
+
 import { authenticateToken } from '../middleware/auth';
 import { authorizeRoles } from '../middleware/authorizeRoles';
-import { responseHandler } from '../utils/responseHandler';
+
 import { getUserEmailFromRequest } from '../utils/authHelpers';
+import { responseHandler } from '../utils/responseHandler';
 import { logger } from '../utils/logger';
-import { AdminService } from '../services/admin.service';
 
 const router = Router();
 

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -13,24 +13,7 @@ const router = Router();
 router.post('/user/signup', async (req: Request, res: Response) => {
   const { name, email, password } = req.body;
 
-  if (!name || !email || !password) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Name, email, and password are required' },
-      'POST',
-    );
-  }
-
-  if (password.length < 8) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Password must be at least 8 characters long.' },
-      'POST',
-    );
-  }
-
   const result = await UserService.userSignUp(name, email, password);
-
   return responseHandler(res, result, 'POST');
 });
 
@@ -38,24 +21,7 @@ router.post('/user/signup', async (req: Request, res: Response) => {
 router.post('/user/signin', async (req: Request, res: Response) => {
   const { email, password } = req.body;
 
-  if (!email || !password) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Email and password are required' },
-      'POST',
-    );
-  }
-
-  if (password.length < 8) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Password must be at least 8 characters long.' },
-      'POST',
-    );
-  }
-
   const result = await UserService.userSingIn(email, password);
-
   return responseHandler(res, result, 'POST');
 });
 

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -29,28 +29,7 @@ router.post('/user/signup', async (req: Request, res: Response) => {
     );
   }
 
-  // Create user via Supabase Auth
-  const signUpResult = await SupabaseProvider.signUp(email, password);
-  if (!signUpResult.success) {
-    return responseHandler(
-      res,
-      { success: false, error: signUpResult.error || 'Signup failed' },
-      'POST',
-    );
-  }
-
-  const supabaseUserId = signUpResult.data.user?.id;
-
-  if (!supabaseUserId) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Signup failed: User ID is null' },
-      'POST',
-    );
-  }
-
-  // Store userdata
-  const result = await UserService.userCreateUser(supabaseUserId, name, email);
+  const result = await UserService.userSignUp(name, email, password);
 
   return responseHandler(res, result, 'POST');
 });

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -73,34 +73,7 @@ router.post('/user/change-password', authenticateToken, async (req: Request, res
   const authHeader = req.headers.authorization;
   const token = authHeader?.split(' ')[1];
 
-  if (!newPassword || newPassword.length < 8) {
-    return responseHandler(
-      res,
-      { success: false, error: 'New password must be at least 8 characters long.' },
-      'POST',
-    );
-  }
-
-  if (!userId) {
-    return responseHandler(res, { success: false, error: 'User not authenticated.' }, 'POST');
-  }
-
-  if (!token) {
-    return responseHandler(res, { success: false, error: 'Missing or invalid token.' }, 'POST');
-  }
-
-  const changePasswordResult = await SupabaseProvider.userChangePassword(token, newPassword);
-
-  if (!changePasswordResult.success) {
-    return responseHandler(res, { success: false, error: changePasswordResult.error }, 'POST');
-  }
-
-  const result = {
-    success: true,
-    data: {
-      message: 'Password changed successfully',
-    },
-  };
+  const result = await UserService.userChangePassword(userId, newPassword, token);
 
   return responseHandler(res, result, 'POST');
 });

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -54,25 +54,7 @@ router.post('/user/signin', async (req: Request, res: Response) => {
     );
   }
 
-  // Sign in via Supabase Auth
-  const signInResult = await SupabaseProvider.signIn(email, password);
-
-  if (!signInResult.success) {
-    return responseHandler(res, { success: false, error: signInResult.error }, 'POST');
-  }
-
-  const { user, session } = signInResult.data;
-
-  if (!session?.access_token) {
-    return responseHandler(res, { success: false, error: 'Session token missing' }, 'POST');
-  }
-
-  const result = {
-    success: true,
-    data: {
-      loggedInUser: user.email,
-    },
-  };
+  const result = await UserService.userSingIn(email, password);
 
   return responseHandler(res, result, 'POST');
 });

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -64,14 +64,6 @@ router.post('/user/refresh-token', async (req: Request, res: Response) => {
 router.delete('/user/delete-account', authenticateToken, async (req: Request, res: Response) => {
   const userId = typeof req.user?.sub === 'string' ? req.user.sub : undefined; //`sub` is the Supabase user ID from the JWT token
 
-  if (!userId) {
-    return responseHandler(
-      res,
-      { success: false, error: 'Unauthorized: User ID not found.' },
-      'DELETE',
-    );
-  }
-
   const result = await UserService.userDeleteAccount(userId);
 
   return responseHandler(res, result, 'DELETE');

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -61,18 +61,7 @@ router.post('/user/signin', async (req: Request, res: Response) => {
 
 // POST User signs out
 router.post('/user/signout', async (_req: Request, res: Response) => {
-  const signOutResult = await SupabaseProvider.signOut();
-
-  if (!signOutResult.success) {
-    return responseHandler(res, { success: false, error: signOutResult.error }, 'POST');
-  }
-
-  const result = {
-    success: true,
-    data: {
-      message: 'User signed out successfully',
-    },
-  };
+  const result = await UserService.userSignOut();
 
   return responseHandler(res, result, 'POST');
 });

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -44,27 +44,11 @@ router.post('/user/change-password', authenticateToken, async (req: Request, res
   return responseHandler(res, result, 'POST');
 });
 
-// POST User resets password
+// POST User requests password magic link
 router.post('/user/send-magic-link', async (req: Request, res: Response) => {
   const { email } = req.body;
 
-  if (!email) {
-    return responseHandler(res, { success: false, error: 'Email is required' }, 'POST');
-  }
-
-  const sendMagicLinkResult = await SupabaseProvider.sendMagicLink(email);
-
-  if (!sendMagicLinkResult.success) {
-    return responseHandler(res, { success: false, error: sendMagicLinkResult.error }, 'POST');
-  }
-
-  const result = {
-    success: true,
-    data: {
-      message: 'Password reset link sent to email.',
-      email,
-    },
-  };
+  const result = await UserService.userRequestMagicLink(email);
 
   return responseHandler(res, result, 'POST');
 });

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -4,7 +4,8 @@ import { handlePrismaRequestError } from '../utils/errorHandler';
 import { validateUserInput, validateId } from '../utils/inputValidation';
 import { logger } from '../utils/logger';
 
-import { User, PublicUser, ServiceResponse } from '../types/types';
+import { PublicUser, ServiceResponse } from '../types/types';
+import type { User } from '@prisma/client';
 import { SupabaseProvider } from '../providers/supabase.provider';
 
 export const AdminService = {

--- a/backend/src/services/subscribers.service.ts
+++ b/backend/src/services/subscribers.service.ts
@@ -33,7 +33,7 @@ export const SubscribersService = {
         data: { email },
       });
 
-      await logger.success(`[Subscribers Service] Email registered successfully:`, email);
+      logger.success(`[Subscribers Service] Email registered successfully:`, email);
       return { success: true, data: newEmail };
     } catch (error) {
       return handlePrismaRequestError(error, 'registering email', 'SubscribersService');

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -103,6 +103,38 @@ export const UserService = {
     };
   },
 
+  async userChangePassword(
+    userId: string | undefined,
+    newPassword: string,
+    token: string | undefined,
+  ): Promise<ServiceResponse<null>> {
+    if (!userId) {
+      return { success: false, error: 'User not authenticated.' };
+    }
+
+    if (!newPassword || newPassword.length < 8) {
+      return { success: false, error: 'New password must be at least 8 characters long.' };
+    }
+
+    if (!token) {
+      return { success: false, error: 'Missing or invalid token.' };
+    }
+
+    const changePasswordResult = await SupabaseProvider.userChangePassword(token, newPassword);
+
+    if (!changePasswordResult.success) {
+      logger.error(
+        `[UserService] Failed to change password for user ${userId}: ${changePasswordResult.error}`,
+      );
+      return { success: false, error: changePasswordResult.error };
+    }
+
+    return {
+      success: true,
+      data: null,
+    };
+  },
+
   async userDeleteAccount(userId: string): Promise<ServiceResponse<null>> {
     const idValidation = validateId(userId);
 

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -24,10 +24,12 @@ export const UserService = {
 
   async userSignUp(name: string, email: string, password: string): Promise<ServiceResponse<User>> {
     if (!name || !email || !password) {
+      logger.warn('[UserService] userSignUp: Missing required fields (name, email, or password).');
       return { success: false, error: 'Name, email, and password are required' };
     }
 
     if (password.length < 8) {
+      logger.warn('[UserService] userSignUp: Password too short.');
       return { success: false, error: 'Password must be at least 8 characters long.' };
     }
 
@@ -50,6 +52,7 @@ export const UserService = {
     const supabaseUserId = signUpResult.data.user?.id;
 
     if (!supabaseUserId) {
+      logger.error(`[UserService] Supabase sign-up succeeded but missing user ID for ${email}.`);
       return { success: false, error: 'Signup failed: Missing user ID' };
     }
 
@@ -62,10 +65,12 @@ export const UserService = {
     password: string,
   ): Promise<ServiceResponse<{ email: string; accessToken: string }>> {
     if (!email || !password) {
+      logger.warn('[UserService] userSignIn: Missing email or password.');
       return { success: false, error: 'Email and password are required' };
     }
 
     if (password.length < 8) {
+      logger.warn('[UserService] userSignIn: Password too short.');
       return { success: false, error: 'Password must be at least 8 characters long.' };
     }
 
@@ -85,11 +90,11 @@ export const UserService = {
     }
 
     if (!user.email) {
+      logger.error(`[UserService] Supabase returned no email for user ${email}.`);
       return { success: false, error: 'Email not returned from Supabase' };
     }
 
     logger.success(`[UserService] User signed in: ${user.email}`);
-
     return {
       success: true,
       data: {
@@ -107,6 +112,7 @@ export const UserService = {
       return { success: false, error: signOutResult.error };
     }
 
+    logger.success('[UserService] User signed out successfully.');
     return {
       success: true,
       data: null,
@@ -119,14 +125,19 @@ export const UserService = {
     token: string | undefined,
   ): Promise<ServiceResponse<null>> {
     if (!userId) {
+      logger.warn('[UserService] userChangePassword: Missing userId — user not authenticated.');
       return { success: false, error: 'User not authenticated.' };
     }
 
     if (!newPassword || newPassword.length < 8) {
+      logger.warn(
+        `[UserService] userChangePassword: Invalid newPassword provided by user ${userId}.`,
+      );
       return { success: false, error: 'New password must be at least 8 characters long.' };
     }
 
     if (!token) {
+      logger.warn(`[UserService] userChangePassword: Missing or invalid token for user ${userId}.`);
       return { success: false, error: 'Missing or invalid token.' };
     }
 
@@ -139,9 +150,34 @@ export const UserService = {
       return { success: false, error: changePasswordResult.error };
     }
 
+    logger.success(`[UserService] Password changed successfully for user ${userId}.`);
     return {
       success: true,
       data: null,
+    };
+  },
+
+  async userRequestMagicLink(email: string): Promise<ServiceResponse<{ email: string }>> {
+    if (!email) {
+      logger.warn('[UserService] userRequestMagicLink: Missing email in request.');
+      return { success: false, error: 'Email is required' };
+    }
+
+    const sendMagicLinkResult = await SupabaseProvider.sendMagicLink(email);
+
+    if (!sendMagicLinkResult.success) {
+      logger.error(
+        `[UserService] Failed to send password magic link for  user ${email}: ${sendMagicLinkResult.error}`,
+      );
+      return { success: false, error: sendMagicLinkResult.error };
+    }
+
+    logger.success(`[UserService] Magic link successfully sent to ${email}.`);
+    return {
+      success: true,
+      data: {
+        email,
+      },
     };
   },
 
@@ -149,7 +185,7 @@ export const UserService = {
     const idValidation = validateId(userId);
 
     if (!idValidation.success) {
-      logger.error(
+      logger.warn(
         `[UserService] Failed to delete account - ID validation error:: ${idValidation.error}`,
       );
       return { success: false, error: idValidation.error ?? '' };
@@ -172,6 +208,7 @@ export const UserService = {
       logger.success(`[UserService] Account deleted successfully ${userId}`);
       return { success: true, data: null };
     } catch (error) {
+      logger.error(`[UserService] Unexpected error while deleting account ${userId}`, error);
       return handlePrismaRequestError(error, 'deleting user', 'UserService');
     }
   },

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -27,7 +27,7 @@ export const UserService = {
         data: { id, name, email, role: 'USER' },
       });
 
-      logger.success(`[UserService] User created successfully:`, user.email);
+      logger.success(`[UserService] User created successfully: ${user.email}`);
       return { success: true, data: user };
     } catch (error) {
       return handlePrismaRequestError(error, 'creating user', 'UserService');
@@ -86,6 +86,20 @@ export const UserService = {
         email: user.email,
         accessToken,
       },
+    };
+  },
+
+  async userSignOut(): Promise<ServiceResponse<null>> {
+    const signOutResult = await SupabaseProvider.signOut();
+
+    if (!signOutResult.success) {
+      logger.error(`[UserService] Supabase sign-out failed: ${signOutResult.error}`);
+      return { success: false, error: signOutResult.error };
+    }
+
+    return {
+      success: true,
+      data: null,
     };
   },
 

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,7 +1,7 @@
 export interface AuthenticatedUser {
   sub: string;
   email?: string;
-  role?: string;
+  role: 'USER' | 'ADMIN';
 }
 
 declare global {
@@ -11,3 +11,5 @@ declare global {
     }
   }
 }
+
+export {};

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,9 +1,13 @@
-import { JwtPayload } from 'jsonwebtoken';
+export interface AuthenticatedUser {
+  sub: string;
+  email?: string;
+  role?: string;
+}
 
 declare global {
   namespace Express {
     interface Request {
-      user?: JwtPayload | string;
+      user?: AuthenticatedUser;
     }
   }
 }

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -12,6 +12,12 @@ export interface AuthUser {
   email: string;
 }
 
+export interface AuthenticatedUser {
+  sub: string;
+  email?: string;
+  role: 'USER' | 'ADMIN';
+}
+
 export interface Tour {
   id: number;
   uniqueId: number;

--- a/backend/src/utils/errorHandler.ts
+++ b/backend/src/utils/errorHandler.ts
@@ -60,6 +60,11 @@ export const handlePrismaRequestError = (
     }
   }
 
-  logger.error(`[${serviceName}] Unexpected error (${action}):`, error);
+  if (error instanceof Prisma.PrismaClientUnknownRequestError) {
+    logger.error(`[${serviceName}] Unknown Prisma request error during ${action}:`, error.message);
+    return { success: false, error: 'Unknown database error. Please try again.' };
+  }
+
+  logger.error(`[${serviceName}] Unexpected error during (${action}):`, error);
   return { success: false, error: 'An unexpected error occurred.' };
 };

--- a/backend/src/utils/inputValidation.ts
+++ b/backend/src/utils/inputValidation.ts
@@ -57,7 +57,7 @@ export const validateUserInput = (
   return { success: true };
 };
 
-export const validateId = (id: string): { success: boolean; error?: string } => {
+export const validateId = (id: string | undefined): { success: boolean; error?: string } => {
   if (!id || typeof id !== 'string') {
     return { success: false, error: 'User ID is required' };
   }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -12,6 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["./node_modules/@types", "./src/types"]
   },
-  "include": ["src"],
+  "include": ["src", "src/types"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# Pull Request Summary: Refactor User Supabase Logic to Service Layer

This PR introduces a structural refactor of the user service layer by centralizing all Supabase-related logic and standardizing validation and logging practices.

## Key Changes

**Supabase logic moved out of route handlers and service methods**
  - Centralized all `signUp`, `signIn`, `signOut`, `refreshToken`, `changePassword`, `sendMagicLink`, and `deleteUserProfile` calls inside the `SupabaseProvider`.
  - Improves modularity, readability, and testability.
**Service-level validations standardized**
  - Centralized `userId` validation logic for actions like account deletion and token refresh.
  - Added input checks (e.g., minimum password length) and consistent error responses.

**Improved error handling**
  - Moved `SupabaseProvider.deleteUserProfile` call outside the try/catch block to avoid suppressing external service errors.
  - Standardized logger usage across all user-related actions.

**Refined method names and fixed typos**
  - Corrected a method name typo (`userSignIn`).
  - Enhanced naming clarity for maintainability.

## Affected Files

- `user.service.ts`
- `supabase.provider.ts`
- Validation and logging utilities

