### PR TITLE
Refactor/centralize prisma calls

### DIFF
--- a/backend/src/middleware/authorizeRoles.ts
+++ b/backend/src/middleware/authorizeRoles.ts
@@ -30,7 +30,8 @@ export const authorizeRoles = (...allowedRoles: string[]) => {
       }
 
       if (user.role !== 'USER' && user.role !== 'ADMIN') {
-        return res.status(403).json({ error: 'Invalid role' });
+        res.status(403).json({ error: 'Invalid role' });
+        return;
       }
 
       // 4. attach role to the request

--- a/backend/src/providers/prisma.provider.ts
+++ b/backend/src/providers/prisma.provider.ts
@@ -56,4 +56,20 @@ export const PrismaProvider = {
       return handlePrismaRequestError(error, 'fetching users', 'AdminService');
     }
   },
+
+  async getUserById(userId: string): Promise<ServiceResponse<PublicUser>> {
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+      });
+
+      if (!user) {
+        return { success: false, error: 'User not found.' };
+      }
+
+      return { success: true, data: { id: user.id, name: user.name, email: user.email } };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'fetching user by ID', 'AdminService');
+    }
+  },
 };

--- a/backend/src/providers/prisma.provider.ts
+++ b/backend/src/providers/prisma.provider.ts
@@ -72,4 +72,14 @@ export const PrismaProvider = {
       return handlePrismaRequestError(error, 'fetching user by ID', 'AdminService');
     }
   },
+
+  async deleteUserById(userId: string): Promise<ServiceResponse<null>> {
+    try {
+      await prisma.user.delete({ where: { id: userId } });
+
+      return { success: true, data: null };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'deleting user', 'AdminService');
+    }
+  },
 };

--- a/backend/src/providers/prisma.provider.ts
+++ b/backend/src/providers/prisma.provider.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../db/prisma';
 
 import type { User } from '@prisma/client';
-import { ServiceResponse } from '../types/types';
+import { ServiceResponse, PublicUser } from '../types/types';
 
 import { handlePrismaRequestError } from '../utils/errorHandler';
 
@@ -22,6 +22,38 @@ export const PrismaProvider = {
       return { success: true, data: user as User };
     } catch (error) {
       return handlePrismaRequestError(error, 'creating user', 'PrismaProvider');
+    }
+  },
+
+  async getUsers(
+    limit: number = 20,
+    cursor?: string,
+  ): Promise<
+    ServiceResponse<{
+      users: PublicUser[];
+      nextCursor: string | null;
+    }>
+  > {
+    try {
+      const safeLimit = Math.max(1, Math.min(limit, 100));
+
+      const users = await prisma.user.findMany({
+        take: safeLimit,
+        skip: cursor ? 1 : 0,
+        cursor: cursor ? { id: cursor } : undefined,
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      });
+
+      const nextCursor = users.length === safeLimit ? users[users.length - 1].id : null;
+
+      return { success: true, data: { users, nextCursor } };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'fetching users', 'AdminService');
     }
   },
 };

--- a/backend/src/providers/prisma.provider.ts
+++ b/backend/src/providers/prisma.provider.ts
@@ -1,0 +1,27 @@
+import { prisma } from '../db/prisma';
+
+import type { User } from '@prisma/client';
+import { ServiceResponse } from '../types/types';
+
+import { handlePrismaRequestError } from '../utils/errorHandler';
+
+export const PrismaProvider = {
+  client: prisma,
+
+  async createUser(userData: {
+    id: string;
+    name: string;
+    email: string;
+    role: 'USER' | 'ADMIN';
+  }): Promise<ServiceResponse<User>> {
+    try {
+      const user = await prisma.user.create({
+        data: userData,
+      });
+
+      return { success: true, data: user as User };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'creating user', 'PrismaProvider');
+    }
+  },
+};

--- a/backend/src/providers/supabase.provider.ts
+++ b/backend/src/providers/supabase.provider.ts
@@ -1,4 +1,4 @@
-import { Session, AuthUser, User as SupabaseUser } from '@supabase/supabase-js';
+import { Session, User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase, supabaseAdmin, getSupabaseWithToken } from '../config/supabase';
 
 import { ServiceResponse as SupabaseResult } from '../types/types';

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -61,12 +61,14 @@ router.get(
   authenticateToken,
   authorizeRoles('ADMIN'),
   async (req: Request, res: Response) => {
-    const cursor = req.query.cursor as string | undefined;
     const parsedLimit = parseInt(req.query.limit as string);
-    const limit = isNaN(parsedLimit) ? 20 : parsedLimit;
+    const cursor = req.query.cursor as string | undefined;
+
+    // Default limit + clamp limit
+    const limit = Math.max(1, Math.min(isNaN(parsedLimit) ? 20 : parsedLimit, 100));
 
     const adminEmail = getUserEmailFromRequest(req);
-    const result = await AdminService.getUsers(cursor, limit);
+    const result = await AdminService.getUsers(limit, cursor);
 
     if (result.success) {
       logger.info(

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -58,14 +58,14 @@ export const AdminService = {
       nextCursor: string | null;
     }>
   > {
-    const result = await PrismaProvider.getUsers(limit, cursor);
+    const getUsersResult = await PrismaProvider.getUsers(limit, cursor);
 
-    if (!result.success) {
-      logger.error(`[AdminService] Failed to fetch users | Error: ${result.error}`);
-      return result;
+    if (!getUsersResult.success) {
+      logger.error(`[AdminService] Failed to fetch users | Error: ${getUsersResult.error}`);
+      return getUsersResult;
     }
 
-    const { users, nextCursor } = result.data;
+    const { users, nextCursor } = getUsersResult.data;
 
     logger.success(
       `[AdminService] Retrieved ${users.length} users | Cursor: ${cursor ?? 'none'} | NextCursor: ${nextCursor ?? 'null'}`,
@@ -81,22 +81,17 @@ export const AdminService = {
       return { success: false, error: idValidation.error ?? '' };
     }
 
-    try {
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-      });
+    const getUserResult = await PrismaProvider.getUserById(userId);
 
-      if (!user) {
-        logger.error(`[AdminService] User not found with ID: ${userId}`);
-        return { success: false, error: 'User not found.' };
-      }
-
-      logger.success(`[AdminService] User retrieved | ID: ${user.id} | Email: ${user.email}`);
-
-      return { success: true, data: user };
-    } catch (error) {
-      return handlePrismaRequestError(error, 'fetching user by ID', 'AdminService');
+    if (!getUserResult.success) {
+      logger.error(`[AdminService] Failed to get user ${userId}: ${getUserResult.error}`);
+      return getUserResult;
     }
+
+    const user = getUserResult.data;
+    logger.success(`[AdminService] User retrieved | ID: ${user.id} | Email: ${user.email}`);
+
+    return { success: true, data: user };
   },
 
   async deleteUserById(userId: string): Promise<ServiceResponse<null>> {

--- a/backend/src/services/admin.service.ts
+++ b/backend/src/services/admin.service.ts
@@ -8,6 +8,7 @@ import { PublicUser, ServiceResponse } from '../types/types';
 import type { User } from '@prisma/client';
 
 import { SupabaseProvider } from '../providers/supabase.provider';
+import { PrismaProvider } from '../providers/prisma.provider';
 
 export const AdminService = {
   async adminCreateUser(
@@ -35,21 +36,17 @@ export const AdminService = {
       return { success: false, error: supabaseCreateResult.error };
     }
 
-    try {
-      const user = await prisma.user.create({
-        data: {
-          id: supabaseCreateResult.data.id,
-          name,
-          email,
-          role,
-        },
-      });
+    const prismaCreateResult = await PrismaProvider.createUser({
+      id: supabaseCreateResult.data.id,
+      name,
+      email,
+      role,
+    });
 
-      logger.success(`[AdminService] User created successfully:`, user.email);
-      return { success: true, data: user as User };
-    } catch (error) {
-      return handlePrismaRequestError(error, 'creating user', 'AdminService');
-    }
+    if (!prismaCreateResult.success) return prismaCreateResult;
+
+    logger.success(`[AdminService] User created successfully:`, prismaCreateResult.data.email);
+    return { success: true, data: prismaCreateResult.data as User };
   },
 
   async getUsers(

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -6,20 +6,23 @@ import { logger } from '../utils/logger';
 
 import { ServiceResponse } from '../types/types';
 import type { User } from '@prisma/client';
+
 import { SupabaseProvider } from '../providers/supabase.provider';
+import { PrismaProvider } from '../providers/prisma.provider';
 
 export const UserService = {
   async _userCreateUser(id: string, name: string, email: string): Promise<ServiceResponse<User>> {
-    try {
-      const user = await prisma.user.create({
-        data: { id, name, email, role: 'USER' },
-      });
+    const prismaCreateResult = await PrismaProvider.createUser({
+      id,
+      name,
+      email,
+      role: 'USER',
+    });
 
-      logger.success(`[UserService] User created successfully: ${user.email}`);
-      return { success: true, data: user };
-    } catch (error) {
-      return handlePrismaRequestError(error, 'creating user', 'UserService');
-    }
+    if (!prismaCreateResult.success) return prismaCreateResult;
+
+    logger.success(`[UserService] User created successfully: ${prismaCreateResult.data.email}`);
+    return { success: true, data: prismaCreateResult.data };
   },
 
   async userSignUp(name: string, email: string, password: string): Promise<ServiceResponse<User>> {


### PR DESCRIPTION

# Description

This pull request refactors several service methods to delegate database operations to the centralized `PrismaProvider`, improving separation of concerns, reusability, and testability.

---

# Changes Included

#### PrismaProvider

- Added `getUserById(userId)`
- Added `deleteUserById(userId)`

# AdminService

- Refactored `getUserById` to:
  - Validate `userId` input
  - Use `PrismaProvider.getUserById`
- Refactored `deleteUserById` to:
  - Use `PrismaProvider.deleteUserById` for database deletion
  - Preserve Supabase auth deletion flow

# UserService

- Refactored `userDeleteAccount` to:
  - Validate `userId`
  - Use `SupabaseProvider.deleteUserProfile`
  - Use `PrismaProvider.deleteUserById` for database deletion

---

# Benefits

- Clear separation of data access logic from service logic
- Centralized Prisma error handling with `handlePrismaRequestError`
- Consistent `ServiceResponse<T>` structure across layers
- Improved testability and maintainability
