### PR TITLE
refactor: move Prisma subscriber operations to provider layer

### DIFF
--- a/backend/src/providers/prisma.provider.ts
+++ b/backend/src/providers/prisma.provider.ts
@@ -25,6 +25,18 @@ export const PrismaProvider = {
     }
   },
 
+  async createSubscriber(email: string): Promise<ServiceResponse<{ id: string; email: string }>> {
+    try {
+      const subscriber = await prisma.betaSubscribers.create({
+        data: { email },
+      });
+
+      return { success: true, data: { id: subscriber.id, email: subscriber.email } };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'creating user', 'PrismaProvider');
+    }
+  },
+
   async getUsers(
     limit: number = 20,
     cursor?: string,

--- a/backend/src/services/subscribers.service.ts
+++ b/backend/src/services/subscribers.service.ts
@@ -1,10 +1,9 @@
-import { prisma } from '../db/prisma.js';
-
-import { handlePrismaRequestError } from '../utils/errorHandler.js';
 import { checkRequiredFields, emailFormattingCheck } from '../utils/inputValidation.js';
 import { logger } from '../utils/logger.js';
 
 import { ServiceResponse } from '../types/types.js';
+
+import { PrismaProvider } from '../providers/prisma.provider.js';
 
 export const SubscribersService = {
   async registerEmailForBeta(
@@ -28,15 +27,12 @@ export const SubscribersService = {
       };
     }
 
-    try {
-      const newEmail = await prisma.betaSubscribers.create({
-        data: { email },
-      });
+    const subscribeResult = await PrismaProvider.createSubscriber(email);
 
+    if (subscribeResult.success) {
       logger.success(`[Subscribers Service] Email registered successfully:`, email);
-      return { success: true, data: newEmail };
-    } catch (error) {
-      return handlePrismaRequestError(error, 'registering email', 'SubscribersService');
     }
+
+    return subscribeResult;
   },
 };


### PR DESCRIPTION
## Implement Provider Layer for Beta Subscribers

### Changes:
- Moved Prisma operations from `SubscribersService` to provider layer
- Updated service to focus on business logic and validation only
- Fixed return type to include both `id` and `email` fields

### Benefits:
- **Separation of Concerns**: Clear distinction between data access and business logic
- **Testability**: Easy to mock provider layer for unit testing services
- **Reusability**: Provider methods can be used by multiple services
- **Maintainability**: Database operations centralized in one location
- **Database Independence**: Easier to swap ORMs or data sources later